### PR TITLE
Subscription Issue Fix

### DIFF
--- a/src/app/api/subscriptions/route.ts
+++ b/src/app/api/subscriptions/route.ts
@@ -75,10 +75,44 @@ export async function POST(request: Request) {
   }
 }
 
+// export async function GET() {
+//   try {
+//     const response = await paystackInstance.subscription.list();
+//     return Response.json(response);
+//   } catch (error) {
+//     return Response.json({ error }, { status: 500 });
+//   }
+// }
 export async function GET() {
   try {
-    const response = await paystackInstance.subscription.list();
-    return Response.json(response);
+    let allSubscriptions: unknown[] = [];
+    let currentPage = 1;
+    let totalPages = 1;
+
+    do {
+      const response = await paystackInstance.subscription.list({
+        page: currentPage,
+        perPage: 50,
+      });
+      if ("data" in response) {
+        allSubscriptions = [...allSubscriptions, ...response.data];
+        totalPages = response.meta.pageCount;
+      } else {
+        throw new Error("BadRequest received from Paystack API");
+      }
+      currentPage++;
+    } while (currentPage <= totalPages);
+    
+    // return Response.json(response);
+    return Response.json({
+      status: true,
+      message: "All subscriptions retrieved",
+      data: allSubscriptions,
+      meta: {
+        total: allSubscriptions.length,
+        pageCount: totalPages,
+      },
+    });
   } catch (error) {
     return Response.json({ error }, { status: 500 });
   }


### PR DESCRIPTION
- Modifies the GET api call for subscriptions to get all subscriptions based on the initial 50 per page, then loops over when when the pageCount meta has more than 1 then results all the data for filtering in  src/app/api/subscriptions/route.ts